### PR TITLE
prevent client paging on aws cli commands

### DIFF
--- a/scripts/create-users.sh
+++ b/scripts/create-users.sh
@@ -48,20 +48,23 @@ for ((u = 1; u <= 4; u++)); do
         --user-pool-id ${POOLID} \
         --username ${USER} \
         --user-attributes Name=email,Value=${USER} ${USER_ATTR},Value="${tenant_id}" ${USER_ATTR2},Value="${tier}" \
-        --no-paginate
+        --no-paginate \
+        --no-cli-pager
 
     aws cognito-idp admin-set-user-password \
         --user-pool-id ${POOLID} \
         --username ${USER} \
         --password ${PASSWORD} \
         --permanent \
-        --no-paginate
+        --no-paginate \
+        --no-cli-pager
 
     aws cognito-idp admin-update-user-attributes \
         --user-pool-id ${POOLID} \
         --username ${USER} \
         --user-attributes Name="email_verified", Value="true" \
-        --no-paginate
+        --no-paginate \
+        --no-cli-pager
 
     HASH=$(python3 ./scripts/secret_hash.py ${USER} ${CLIENTID} ${CLIENTSECRET})
 

--- a/scripts/resize-cloud9-ebs-vol.sh
+++ b/scripts/resize-cloud9-ebs-vol.sh
@@ -15,7 +15,7 @@ VOLUMEID=$(aws ec2 describe-instances \
   --output text)
 
 # Resize the EBS volume.
-aws ec2 modify-volume --volume-id $VOLUMEID --size $SIZE
+aws ec2 modify-volume --volume-id $VOLUMEID --size $SIZE --no-cli-pager
 
 # Wait for the resize to finish.
 while [ \


### PR DESCRIPTION
*Issue #, if available:*
During the "And one last step to bootstrap the environment, let's install the BaseStack which contains Cognito and Istio into the cluster" json documents printed in the console and had to be closed out of to continue.

*Description of changes:*
Included --no-cli-pager flag to prevent client side paging for aws cli commands on setup.sh and deploy.sh
https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-pagination.html#cli-usage-pagination-noclipager

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
