### PR TITLE
Move shared libs

### DIFF
--- a/bin/saas-workshop.ts
+++ b/bin/saas-workshop.ts
@@ -5,6 +5,7 @@ import { TokenVendorStack } from "../lib/token-vendor/infrastructure/token-vendo
 import { ApplicationStack } from "../lib/environment/application-stack";
 import { BaseStack } from "../lib/base/base-stack";
 import { ApplicationAdvancedTierStack } from "../lib/environment/application-advanced-tier-stack";
+import { HelperLibraryBaseImageStack } from "../lib/shared/infrastructure/shared-stack"
 import { TenantTier } from "../lib/enums/tenant-tier";
 import { DestroyPolicySetter } from "../lib/cdk-aspect/destroy-policy-setter";
 
@@ -21,6 +22,8 @@ if (!tlsCertIstio || !tlsKeyIstio) {
     "Please provide the TLS certificate and key for Istio in the environment variables."
   );
 }
+
+const libStack = new HelperLibraryBaseImageStack(app, "HelperLibraryBaseImageStack")
 
 const baseStack = new BaseStack(app, "SaaSMicroserviceBaseStack", {
   env: { account, region },

--- a/bin/saas-workshop.ts
+++ b/bin/saas-workshop.ts
@@ -15,6 +15,7 @@ const region = process.env.CDK_DEFAULT_REGION;
 const deploymentMode = process.env.CDK_PARAM_DEPLOYMENT_MODE || "all";
 const tlsCertIstio = process.env.CDK_PARAM_TLS_CERT_ISTIO;
 const tlsKeyIstio = process.env.CDK_PARAM_TLS_KEY_ISTIO;
+const helperLibraryBaseImageUri = process.env.HELPER_LIBRARY_BASE_IMAGE
 const workshopSSMPrefix = "/saas-workshop";
 
 if (!tlsCertIstio || !tlsKeyIstio) {
@@ -44,6 +45,7 @@ const basicStack = new ApplicationStack(app, "PoolBasicStack", {
   sideCarImageAsset: tokenVendorStack.tokenVendorImage,
   deploymentMode: deploymentMode,
   workshopSSMPrefix: workshopSSMPrefix,
+  helperLibraryBaseImageUri: helperLibraryBaseImageUri
 });
 basicStack.node.addDependency(baseStack);
 
@@ -56,6 +58,7 @@ const tenantBstack = new ApplicationAdvancedTierStack(app, "tenantBstack", {
   deploymentMode: deploymentMode,
   tenantId: "tenant-b",
   workshopSSMPrefix: workshopSSMPrefix,
+  helperLibraryBaseImageUri: helperLibraryBaseImageUri
 });
 tenantBstack.node.addDependency(basicStack);
 
@@ -68,6 +71,7 @@ const tenantEstack = new ApplicationAdvancedTierStack(app, "tenantEstack", {
   deploymentMode: deploymentMode,
   tenantId: "tenant-e",
   workshopSSMPrefix: workshopSSMPrefix,
+  helperLibraryBaseImageUri: helperLibraryBaseImageUri
 });
 tenantEstack.node.addDependency(basicStack);
 
@@ -80,6 +84,7 @@ const tenantCstack = new ApplicationStack(app, "tenantCstack", {
   deploymentMode: deploymentMode,
   tenantTier: TenantTier.Premium,
   workshopSSMPrefix: workshopSSMPrefix,
+  helperLibraryBaseImageUri: helperLibraryBaseImageUri
 });
 tenantCstack.node.addDependency(basicStack);
 

--- a/lib/base/base-stack.ts
+++ b/lib/base/base-stack.ts
@@ -8,7 +8,6 @@ import { CognitoResources } from "../../lib/cognito/cognito-stack";
 import { IstioResources } from "../../lib/eks/istio-stack";
 import { CloudwatchAgentAddOnStack } from "../eks/cloudwatch-agent";
 import { TenantTier } from "../enums/tenant-tier";
-//import { SharedResources } from "../shared/infrastructure/shared-stack";
 
 export interface BaseStackProps extends cdk.StackProps {
   tlsCertIstio: string;
@@ -19,8 +18,7 @@ export interface BaseStackProps extends cdk.StackProps {
 export class BaseStack extends cdk.Stack {
   public readonly eksCluster: EksCluster;
   public readonly cognitoResources: CognitoResources;
-  public readonly istioResources: IstioResources;
-  //public readonly sharedResources: SharedResources;
+  public readonly istioResources: IstioResources;  
   public readonly cloudwatchAgentAddOnStack: CloudwatchAgentAddOnStack;
   public readonly advancedTierEventBus: aws_events.EventBus;
 
@@ -30,8 +28,7 @@ export class BaseStack extends cdk.Stack {
     const tlsCertIstio = props.tlsCertIstio;
     const tlsKeyIstio = props.tlsKeyIstio;
     const workshopSSMPrefix = props.workshopSSMPrefix;
-
-    //const sharedResources = new SharedResources(this, "SharedResources");
+    
     const cognitoResources = new CognitoResources(this, "CognitoResources");
 
     const eksCluster = new EksCluster(this, "EksCluster", {
@@ -86,7 +83,6 @@ export class BaseStack extends cdk.Stack {
     this.eksCluster = eksCluster;
     this.cognitoResources = cognitoResources;
     this.istioResources = istioResources;
-    //this.sharedResources = sharedResources;
     this.cloudwatchAgentAddOnStack = cloudwatchAgentAddOnStack;
 
     new cdk.CfnOutput(this, "CognitoUserPoolId", {

--- a/lib/base/base-stack.ts
+++ b/lib/base/base-stack.ts
@@ -1,5 +1,4 @@
 import * as cdk from "aws-cdk-lib";
-import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as aws_events from "aws-cdk-lib/aws-events";
 import * as aws_events_targets from "aws-cdk-lib/aws-events-targets";
 import * as logs from "aws-cdk-lib/aws-logs";
@@ -9,7 +8,7 @@ import { CognitoResources } from "../../lib/cognito/cognito-stack";
 import { IstioResources } from "../../lib/eks/istio-stack";
 import { CloudwatchAgentAddOnStack } from "../eks/cloudwatch-agent";
 import { TenantTier } from "../enums/tenant-tier";
-import { SharedResources } from "../shared/infrastructure/shared-stack";
+//import { SharedResources } from "../shared/infrastructure/shared-stack";
 
 export interface BaseStackProps extends cdk.StackProps {
   tlsCertIstio: string;
@@ -21,7 +20,7 @@ export class BaseStack extends cdk.Stack {
   public readonly eksCluster: EksCluster;
   public readonly cognitoResources: CognitoResources;
   public readonly istioResources: IstioResources;
-  public readonly sharedResources: SharedResources;
+  //public readonly sharedResources: SharedResources;
   public readonly cloudwatchAgentAddOnStack: CloudwatchAgentAddOnStack;
   public readonly advancedTierEventBus: aws_events.EventBus;
 
@@ -32,7 +31,7 @@ export class BaseStack extends cdk.Stack {
     const tlsKeyIstio = props.tlsKeyIstio;
     const workshopSSMPrefix = props.workshopSSMPrefix;
 
-    const sharedResources = new SharedResources(this, "SharedResources");
+    //const sharedResources = new SharedResources(this, "SharedResources");
     const cognitoResources = new CognitoResources(this, "CognitoResources");
 
     const eksCluster = new EksCluster(this, "EksCluster", {
@@ -87,7 +86,7 @@ export class BaseStack extends cdk.Stack {
     this.eksCluster = eksCluster;
     this.cognitoResources = cognitoResources;
     this.istioResources = istioResources;
-    this.sharedResources = sharedResources;
+    //this.sharedResources = sharedResources;
     this.cloudwatchAgentAddOnStack = cloudwatchAgentAddOnStack;
 
     new cdk.CfnOutput(this, "CognitoUserPoolId", {

--- a/lib/environment/application-advanced-tier-stack.ts
+++ b/lib/environment/application-advanced-tier-stack.ts
@@ -30,7 +30,7 @@ export class ApplicationAdvancedTierStack extends cdk.Stack {
 
     const istioIngressGateway = props.baseStack.istioResources.istioIngressGateway;
     const sideCarImageAsset = props.sideCarImageAsset;
-    const baseImageUri = process.env.HELPER_LIBRARY_BASE_IMAGE
+    const baseImageUri = props.helperLibraryBaseImageUri
     const namespace = props.basicStack.namespace;
     const fulfillmentServiceDNS = props.basicStack.fulfillmentServiceDNS;
     const fulfillmentServicePort = props.basicStack.fulfillmentServicePort;
@@ -95,7 +95,7 @@ export class ApplicationAdvancedTierStack extends cdk.Stack {
         cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
         cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
         eventBus: advancedTierEventBus,
-        baseImage: baseImageUri //props.baseStack.sharedResources.sharedImageAsset,
+        baseImage: baseImageUri
       }
     );
     fulfillmentAdvancedTierStack.node.addDependency(
@@ -130,7 +130,7 @@ export class ApplicationAdvancedTierStack extends cdk.Stack {
       cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
       cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
       namespaceConstruct: tenantSpecificAdvancedTierNamespace,
-      baseImage: baseImageUri, //props.baseStack.sharedResources.sharedImageAsset,
+      baseImage: baseImageUri,
       eventBus: advancedTierEventBus,
       fulfillmentEventDetailType: fulfillmentAdvancedTierStack.eventDetailType,
       fulfillmentEventSource: fulfillmentAdvancedTierStack.eventSource,

--- a/lib/environment/application-advanced-tier-stack.ts
+++ b/lib/environment/application-advanced-tier-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from "aws-cdk-lib";
+import * as ssm from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 import { ApplicationAdvancedTierStackProps } from "../interface/application-advanced-tier-props";
 import { FulfillmentAdvancedTierStack } from "../fulfillment/infrastructure/fulfillment-advanced-tier-stack";
@@ -27,25 +28,19 @@ export class ApplicationAdvancedTierStack extends cdk.Stack {
     });
     const cluster = eksCluster.cluster;
 
-    const istioIngressGateway =
-      props.baseStack.istioResources.istioIngressGateway;
+    const istioIngressGateway = props.baseStack.istioResources.istioIngressGateway;
     const sideCarImageAsset = props.sideCarImageAsset;
-
+    const baseImageUri = process.env.HELPER_LIBRARY_BASE_IMAGE
     const namespace = props.basicStack.namespace;
     const fulfillmentServiceDNS = props.basicStack.fulfillmentServiceDNS;
     const fulfillmentServicePort = props.basicStack.fulfillmentServicePort;
-    const fulfillmentDockerImageAsset =
-      props.basicStack.fulfillmentDockerImageAsset;
+    const fulfillmentDockerImageAsset = props.basicStack.fulfillmentDockerImageAsset;
     const productServiceDNS = props.basicStack.productServiceDNS;
     const productServicePort = props.basicStack.productServicePort;
     const orderServiceDNS = props.basicStack.orderServiceDNS;
     const orderServicePort = props.basicStack.orderServicePort;
-    const cloudwatchAgentLogEndpoint =
-      props.baseStack.cloudwatchAgentAddOnStack.cloudwatchAgentLogEndpoint;
-    const cloudwatchAgentLogGroupName =
-      props.baseStack.cloudwatchAgentAddOnStack.cloudwatchAgentLogGroup
-        .logGroupName;
-
+    const cloudwatchAgentLogEndpoint = props.baseStack.cloudwatchAgentAddOnStack.cloudwatchAgentLogEndpoint;
+    const cloudwatchAgentLogGroupName = props.baseStack.cloudwatchAgentAddOnStack.cloudwatchAgentLogGroup.logGroupName;
     const advancedTierEventBus = props.baseStack.advancedTierEventBus;
 
     const productAdvancedTierStack = new ProductAdvancedTierStack(
@@ -100,7 +95,7 @@ export class ApplicationAdvancedTierStack extends cdk.Stack {
         cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
         cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
         eventBus: advancedTierEventBus,
-        baseImage: props.baseStack.sharedResources.sharedImageAsset,
+        baseImage: baseImageUri //props.baseStack.sharedResources.sharedImageAsset,
       }
     );
     fulfillmentAdvancedTierStack.node.addDependency(
@@ -135,7 +130,7 @@ export class ApplicationAdvancedTierStack extends cdk.Stack {
       cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
       cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
       namespaceConstruct: tenantSpecificAdvancedTierNamespace,
-      baseImage: props.baseStack.sharedResources.sharedImageAsset,
+      baseImage: baseImageUri, //props.baseStack.sharedResources.sharedImageAsset,
       eventBus: advancedTierEventBus,
       fulfillmentEventDetailType: fulfillmentAdvancedTierStack.eventDetailType,
       fulfillmentEventSource: fulfillmentAdvancedTierStack.eventSource,

--- a/lib/environment/application-stack.ts
+++ b/lib/environment/application-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import * as aws_events from "aws-cdk-lib/aws-events";
 import * as aws_events_targets from "aws-cdk-lib/aws-events-targets";
 import * as logs from "aws-cdk-lib/aws-logs";
+import * as ssm from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 import { ProductStack } from "../product/infrastructure/product-stack";
 import { FulfillmentStack } from "../fulfillment/infrastructure/fulfillment-stack";
@@ -11,6 +12,7 @@ import { DockerImageAsset } from "aws-cdk-lib/aws-ecr-assets";
 import { TenantTier } from "../enums/tenant-tier";
 import { EksCluster } from "../eks/eks-blueprint-stack";
 import { InvoiceStack } from "../invoice/infrastructure/invoice-stack";
+
 
 export class ApplicationStack extends cdk.Stack {
   public readonly fulfillmentServiceDNS: string;
@@ -34,18 +36,15 @@ export class ApplicationStack extends cdk.Stack {
 
     const deploymentMode = props.deploymentMode;
     const workshopSSMPrefix = props.workshopSSMPrefix;
+    const baseImageUri = process.env.HELPER_LIBRARY_BASE_IMAGE    
 
     const eksCluster = new EksCluster(this, "EksCluster", {
       workshopSSMPrefix: workshopSSMPrefix,
     });
     const cluster = eksCluster.cluster;
-    const cloudwatchAgentLogEndpoint =
-      props.baseStack.cloudwatchAgentAddOnStack.cloudwatchAgentLogEndpoint;
-    const cloudwatchAgentLogGroupName =
-      props.baseStack.cloudwatchAgentAddOnStack.cloudwatchAgentLogGroup
-        .logGroupName;
-    const istioIngressGateway =
-      props.baseStack.istioResources.istioIngressGateway;
+    const cloudwatchAgentLogEndpoint = props.baseStack.cloudwatchAgentAddOnStack.cloudwatchAgentLogEndpoint;
+    const cloudwatchAgentLogGroupName = props.baseStack.cloudwatchAgentAddOnStack.cloudwatchAgentLogGroup.logGroupName;
+    const istioIngressGateway = props.baseStack.istioResources.istioIngressGateway;
 
     const tenantTier = props.tenantTier;
     const tenantId = props.tenantId;
@@ -112,7 +111,7 @@ export class ApplicationStack extends cdk.Stack {
       cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
       cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
       namespaceConstruct: stackNamespace,
-      baseImage: props.baseStack.sharedResources.sharedImageAsset,
+      baseImage: baseImageUri //props.baseStack.sharedResources.sharedImageAsset,
     });
     productStack.node.addDependency(stackNamespace);
     this.productServiceDNS = productStack.productServiceDNS;
@@ -132,7 +131,7 @@ export class ApplicationStack extends cdk.Stack {
         cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
         namespaceConstruct: stackNamespace,
         eventBus: eventBus,
-        baseImage: props.baseStack.sharedResources.sharedImageAsset,
+        baseImage: baseImageUri //props.baseStack.sharedResources.sharedImageAsset,
       });
       fulfillmentStack.node.addDependency(stackNamespace);
       this.fulfillmentServicePort = fulfillmentStack.fulfillmentServicePort;
@@ -153,7 +152,7 @@ export class ApplicationStack extends cdk.Stack {
         cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
         cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
         namespaceConstruct: stackNamespace,
-        baseImage: props.baseStack.sharedResources.sharedImageAsset,
+        baseImage: baseImageUri //props.baseStack.sharedResources.sharedImageAsset,
       });
       orderStack.node.addDependency(stackNamespace);
       orderStack.node.addDependency(fulfillmentStack);
@@ -173,7 +172,7 @@ export class ApplicationStack extends cdk.Stack {
         cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
         cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
         namespaceConstruct: stackNamespace,
-        baseImage: props.baseStack.sharedResources.sharedImageAsset,
+        baseImage: baseImageUri, //props.baseStack.sharedResources.sharedImageAsset,
         eventBus: eventBus,
         fulfillmentEventDetailType: fulfillmentStack.eventDetailType,
         fulfillmentEventSource: fulfillmentStack.eventSource,

--- a/lib/environment/application-stack.ts
+++ b/lib/environment/application-stack.ts
@@ -36,7 +36,7 @@ export class ApplicationStack extends cdk.Stack {
 
     const deploymentMode = props.deploymentMode;
     const workshopSSMPrefix = props.workshopSSMPrefix;
-    const baseImageUri = process.env.HELPER_LIBRARY_BASE_IMAGE    
+    const baseImageUri = props.helperLibraryBaseImageUri
 
     const eksCluster = new EksCluster(this, "EksCluster", {
       workshopSSMPrefix: workshopSSMPrefix,
@@ -111,7 +111,7 @@ export class ApplicationStack extends cdk.Stack {
       cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
       cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
       namespaceConstruct: stackNamespace,
-      baseImage: baseImageUri //props.baseStack.sharedResources.sharedImageAsset,
+      baseImage: baseImageUri
     });
     productStack.node.addDependency(stackNamespace);
     this.productServiceDNS = productStack.productServiceDNS;
@@ -131,7 +131,7 @@ export class ApplicationStack extends cdk.Stack {
         cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
         namespaceConstruct: stackNamespace,
         eventBus: eventBus,
-        baseImage: baseImageUri //props.baseStack.sharedResources.sharedImageAsset,
+        baseImage: baseImageUri
       });
       fulfillmentStack.node.addDependency(stackNamespace);
       this.fulfillmentServicePort = fulfillmentStack.fulfillmentServicePort;
@@ -152,7 +152,7 @@ export class ApplicationStack extends cdk.Stack {
         cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
         cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
         namespaceConstruct: stackNamespace,
-        baseImage: baseImageUri //props.baseStack.sharedResources.sharedImageAsset,
+        baseImage: baseImageUri
       });
       orderStack.node.addDependency(stackNamespace);
       orderStack.node.addDependency(fulfillmentStack);
@@ -172,7 +172,7 @@ export class ApplicationStack extends cdk.Stack {
         cloudwatchAgentLogEndpoint: cloudwatchAgentLogEndpoint,
         cloudwatchAgentLogGroupName: cloudwatchAgentLogGroupName,
         namespaceConstruct: stackNamespace,
-        baseImage: baseImageUri, //props.baseStack.sharedResources.sharedImageAsset,
+        baseImage: baseImageUri,
         eventBus: eventBus,
         fulfillmentEventDetailType: fulfillmentStack.eventDetailType,
         fulfillmentEventSource: fulfillmentStack.eventSource,

--- a/lib/fulfillment/infrastructure/fulfillment-advanced-tier-stack.ts
+++ b/lib/fulfillment/infrastructure/fulfillment-advanced-tier-stack.ts
@@ -52,7 +52,7 @@ export class FulfillmentAdvancedTierStack extends Construct {
           directory: path.join(__dirname, "../app"),
           ...(baseImage && {
             buildArgs: {
-              BASE_IMAGE: baseImage.imageUri,
+              BASE_IMAGE: baseImage,
             },
           }),
         }

--- a/lib/fulfillment/infrastructure/fulfillment-stack.ts
+++ b/lib/fulfillment/infrastructure/fulfillment-stack.ts
@@ -54,7 +54,7 @@ export class FulfillmentStack extends Construct {
           directory: path.join(__dirname, "../app"),
           ...(baseImage && {
             buildArgs: {
-              BASE_IMAGE: baseImage.imageUri,
+              BASE_IMAGE: baseImage,
             },
           }),
         }

--- a/lib/interface/application-props.ts
+++ b/lib/interface/application-props.ts
@@ -12,4 +12,5 @@ export interface ApplicationStackProps extends cdk.StackProps {
   basicStack?: ApplicationStack;
   deploymentMode: string;
   workshopSSMPrefix: string;
+  helperLibraryBaseImageUri?: string;
 }

--- a/lib/interface/microservice-props.ts
+++ b/lib/interface/microservice-props.ts
@@ -3,7 +3,8 @@ import * as eks from "aws-cdk-lib/aws-eks";
 import { TenantTier } from "../enums/tenant-tier";
 
 export interface MicroserviceStackProps {
-  baseImage?: DockerImageAsset;
+  //baseImage?: DockerImageAsset;
+  baseImage?: string
   cluster: eks.ICluster;
   cloudwatchAgentLogEndpoint: string;
   cloudwatchAgentLogGroupName: string;

--- a/lib/invoice/infrastructure/invoice-stack.ts
+++ b/lib/invoice/infrastructure/invoice-stack.ts
@@ -70,7 +70,7 @@ export class InvoiceStack extends Construct {
           directory: path.join(__dirname, "../app"),
           ...(baseImage && {
             buildArgs: {
-              BASE_IMAGE: baseImage.imageUri,
+              BASE_IMAGE: baseImage,
             },
           }),
         }

--- a/lib/order/infrastructure/order-stack.ts
+++ b/lib/order/infrastructure/order-stack.ts
@@ -50,7 +50,7 @@ export class OrderStack extends Construct {
           directory: path.join(__dirname, "../app"),
           ...(baseImage && {
             buildArgs: {
-              BASE_IMAGE: baseImage.imageUri,
+              BASE_IMAGE: baseImage,
             },
           }),
         }

--- a/lib/product/infrastructure/product-stack.ts
+++ b/lib/product/infrastructure/product-stack.ts
@@ -48,7 +48,7 @@ export class ProductStack extends Construct {
           directory: path.join(__dirname, "../app"),
           ...(baseImage && {
             buildArgs: {
-              BASE_IMAGE: baseImage.imageUri,
+              BASE_IMAGE: baseImage,
             },
           }),
         }

--- a/lib/shared/infrastructure/shared-stack.ts
+++ b/lib/shared/infrastructure/shared-stack.ts
@@ -1,12 +1,11 @@
+import * as cdk from "aws-cdk-lib";
 import { DockerImageAsset } from "aws-cdk-lib/aws-ecr-assets";
 import { Construct } from "constructs";
 var path = require("path");
 
-export class SharedResources extends Construct {
-  public readonly sharedImageAsset: DockerImageAsset;
+export class HelperLibraryBaseImageStack extends cdk.Stack {  
   constructor(scope: Construct, id: string) {
     super(scope, id);
-
     const sharedImageAsset = new DockerImageAsset(
       this,
       "SharedImageAssetImage",
@@ -14,7 +13,9 @@ export class SharedResources extends Construct {
         directory: path.join(__dirname, "../app"),
       }
     );
-
-    this.sharedImageAsset = sharedImageAsset;
+    new cdk.CfnOutput(this, "HelperLibraryBaseImageUri", {
+      value: sharedImageAsset.imageUri,
+      exportName: "HelperLibraryBaseImageUri",
+    });
   }
 }

--- a/standalone-eks-stack/deploy-cluster.sh
+++ b/standalone-eks-stack/deploy-cluster.sh
@@ -11,6 +11,6 @@ aws cloudformation deploy \
     --stack-name workshopStack \
     --capabilities CAPABILITY_IAM \
     --parameter-overrides \
-        RepoUrl="https://github.com/somensi-aws/aws-saas-factory-saas-microservices-workshop.git" \
-        RepoBranchName="move-shared-libs" \
+        RepoUrl="https://github.com/aws-samples/aws-saas-factory-saas-microservices-workshop.git" \
+        RepoBranchName="lab-changes" \
         IsWorkshopStudioEnv="no"

--- a/standalone-eks-stack/deploy-cluster.sh
+++ b/standalone-eks-stack/deploy-cluster.sh
@@ -11,6 +11,6 @@ aws cloudformation deploy \
     --stack-name workshopStack \
     --capabilities CAPABILITY_IAM \
     --parameter-overrides \
-        RepoUrl="https://github.com/aws-samples/aws-saas-factory-saas-microservices-workshop.git" \
-        RepoBranchName="v2" \
+        RepoUrl="https://github.com/somensi-aws/aws-saas-factory-saas-microservices-workshop.git" \
+        RepoBranchName="move-shared-libs" \
         IsWorkshopStudioEnv="no"

--- a/standalone-eks-stack/deploy-workshop-resources.sh
+++ b/standalone-eks-stack/deploy-workshop-resources.sh
@@ -6,8 +6,8 @@
 echo "Deploying workshop resources..."
 
 STACK_NAME="WorkshopStack"
-REPO_URL="https://github.com/aws-samples/aws-saas-factory-saas-microservices-workshop.git"
-REPO_BRANCH_NAME="v2"
+REPO_URL="https://github.com/somensi-aws/aws-saas-factory-saas-microservices-workshop.git"
+REPO_BRANCH_NAME="move-shared-libs"
 PARTICIPANT_ASSUMED_ROLE_ARN="$(aws sts get-caller-identity --query 'Arn' --output text)"
 
 STACK_ID=$(aws cloudformation create-stack \

--- a/standalone-eks-stack/deploy-workshop-resources.sh
+++ b/standalone-eks-stack/deploy-workshop-resources.sh
@@ -6,8 +6,8 @@
 echo "Deploying workshop resources..."
 
 STACK_NAME="WorkshopStack"
-REPO_URL="https://github.com/somensi-aws/aws-saas-factory-saas-microservices-workshop.git"
-REPO_BRANCH_NAME="move-shared-libs"
+REPO_URL="https://github.com/aws-samples/aws-saas-factory-saas-microservices-workshop.git"
+REPO_BRANCH_NAME="lab-changes"
 PARTICIPANT_ASSUMED_ROLE_ARN="$(aws sts get-caller-identity --query 'Arn' --output text)"
 
 STACK_ID=$(aws cloudformation create-stack \


### PR DESCRIPTION
*Issue #, if available:*
Split deployments for help image and tenant stacks

*Description of changes:*
Helper lib is a stack instead of Construct
BaseImage is passed in through environment variables
BaseImageUri is string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
